### PR TITLE
Adds Luqas support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.7.0] - 2024-01-12
+
+### Added
+
+- Added support for Luqas and gauges of variant Power, Energy, Current, Voltage. Gauges with unit 'kWh' are considered to be totals.
+
 ## [0.6.0] - 2024-01-12
 
 ### Added

--- a/src/QbusMqttModels/QbusConfigEntity.py
+++ b/src/QbusMqttModels/QbusConfigEntity.py
@@ -7,6 +7,7 @@ class QbusConfigEntity(BaseModel):
     name: str = None
     originalName: str = None
     refId: str = None
-    type: str = None
+    type: str = None,
+    variant: str | None = None,
     actions: dict = {}
     properties: dict = {}

--- a/src/Settings.py
+++ b/src/Settings.py
@@ -5,7 +5,7 @@ import socket
 
 
 class Settings:
-    _VERSION = "v0.6.0"
+    _VERSION = "v0.7.0"
 
 
     def __new__(cls):

--- a/src/Subscribers/QbusConfigSubscriber.py
+++ b/src/Subscribers/QbusConfigSubscriber.py
@@ -310,15 +310,14 @@ class QbusConfigSubscriber(Subscriber):
         message = self._create_base_message(entity, controller)
 
         message.payload.value_template = "{{ value_json['properties']['currentValue'] }}"
-        message.payload.unit_of_measurement =  entity.properties.get("currentValue").get("unit")
+        message.payload.unit_of_measurement = entity.properties.get("currentValue").get("unit")
         message.payload.device_class = self._SUPPORTED_GAUGE_VARIANTS.get(entity.variant)
         message.payload.suggested_display_precision = 2
 
-        # Interpret state class based on name. 
-        # Another option would be to assume kWh is always a total value, otherwise it's a live measurement
-        if "LQS El. Totaal" in entity.name or "LQS El. Dag" in entity.name or "LQS El. Nacht" in entity.name:
-            message.payload.state_class = "total"
-        else:
-            message.payload.state_class = "measurement"
+        match message.payload.unit_of_measurement:
+            case "kWh":
+              message.payload.state_class = "total"
+            case _:
+              message.payload.state_class = "measurement"
 
         return message


### PR DESCRIPTION
Adds support for Luqas.
Luqas adds several gauges to your controller.

Qbus config with all the different gauges
[qbusconfig.json](https://github.com/user-attachments/files/15578305/qbusconfig.json)

See results
![image](https://github.com/thomasddn/qbha/assets/16224711/221201bb-43e4-4910-8f75-49cd138f33d1)
![image](https://github.com/thomasddn/qbha/assets/16224711/f23033ad-2674-46d9-89d7-2375f49024f7)

